### PR TITLE
Replace StructuralCopy by List+ShallowCopy

### DIFF
--- a/lib/automata.gi
+++ b/lib/automata.gi
@@ -176,7 +176,7 @@ if mA <> mB then
 fi;
 
 QA := A!.states;
-T := StructuralCopy( A!.transitions );
+T := List( A!.transitions, ShallowCopy );
 if A!.type <> "epsilon" and B!.type = "epsilon" then
 	Add(T,[]);
 fi;	

--- a/lib/decomp.gi
+++ b/lib/decomp.gi
@@ -140,7 +140,7 @@ InstallGlobalFunction(PlusIndecomposableAut,function(aut)
     states:=NumberStatesOfAutomaton(temp)+2;
     fin:=FinalStatesOfAutomaton(temp);
     acc:=Concatenation([states-1],fin);
-    trans:=StructuralCopy(TransitionMatrixOfAutomaton(temp));
+    trans:=List(TransitionMatrixOfAutomaton(temp), ShallowCopy);
 
     for i in [1..Length(TransitionMatrixOfAutomaton(temp))] do
     	Add(trans[i],trans[i][1],states-1);

--- a/lib/inversion.gi
+++ b/lib/inversion.gi
@@ -77,7 +77,7 @@ end );
 InstallGlobalFunction(LoopFreeAut,function(a)
 local trans,j,i;
 
-trans:=StructuralCopy(a!.transitions);
+trans:=List(a!.transitions, ShallowCopy);
 
 for j in [1..Length(trans[1])] do 
     for i in [1..Length(trans)] do
@@ -105,7 +105,7 @@ local acc,ll,trans,i,j,x,sink;
 
 acc:=FinalStatesOfAutomaton(a);
 ll:=[];
-trans:=StructuralCopy(a!.transitions);
+trans:=List(a!.transitions, ShallowCopy);
 sink:=a!.states+1;
 
 for i in [1..Length(trans)] do


### PR DESCRIPTION
The changes in this PR are supposed to help with making this package compatible with HPC-GAP. They are closely based on <https://github.com/gap-system/gap/blob/master/hpcgap/pkg-diffs/patternclass-2015-11-18.diff>, and that file in turn was added there by @stevelinton 

Perhaps Steve can elaborate as to which problem(s) this solves.

I am adding this as a PR here to increase its visibility, and in the hope that we can stop carrying that patch file in GAP.