### PR TITLE
Turn BOUNDED_CLASS_AUTOMATA_CACHE into a flushable variable

### DIFF
--- a/lib/classAndBasis.gd
+++ b/lib/classAndBasis.gd
@@ -18,7 +18,7 @@
 ##  Returns an automaton, that accepts all rank encoded permutations with
 ##  highest letter being k.
 ##
-DeclareGlobalVariable( "BOUNDED_CLASS_AUTOMATA_CACHE");
+
 DeclareGlobalFunction( "BoundedClassAutomaton" );
 
 #############################################################################

--- a/lib/classAndBasis.gi
+++ b/lib/classAndBasis.gi
@@ -19,7 +19,17 @@
 ##  highest letter being k.
 ##
 
-InstallFlushableValue(BOUNDED_CLASS_AUTOMATA_CACHE,[]);
+if not IsBound(MakeWriteOnceAtomic) then
+    BindGlobal("MakeWriteOnceAtomic", ID_FUNC);
+fi;
+
+BOUNDED_CLASS_AUTOMATA_CACHE :=  MakeWriteOnceAtomic([]);
+
+InstallMethod(FlushCaches, [],function()
+    BOUNDED_CLASS_AUTOMATA_CACHE := MakeWriteOnceAtomic([]);
+    TryNextMethod();
+end);
+
 
 InstallGlobalFunction(BoundedClassAutomaton, function(k)
     local   states,  alphabet,  trans,  i,  j;


### PR DESCRIPTION
Also use `MakeWriteOnceAtomic` to make it HPC-GAP compatible.

In order to retain compatibility with GAP versions before GAP 4.9 (which is not yet released), we also declare `MakeWriteOnceAtomic` (as doing nothing) for these GAP versions.

The changes in this PR are supposed to help with making this package compatible with HPC-GAP. They are closely based on <https://github.com/gap-system/gap/blob/master/hpcgap/pkg-diffs/patternclass-2015-11-18.diff>, and that file in turn was added there by @stevelinton 

I am adding this as a PR here to increase its visibility, and in the hope that we can stop carrying that patch file in GAP.