### PR TITLE
Switch to TestDirectory

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,10 +1,7 @@
-pkgdir := DirectoriesPackageLibrary( "PatternClass", "tst" );
-Test( Filename( pkgdir, "chap2.tst"));
-Test( Filename( pkgdir, "chap3.tst"));
-Test( Filename( pkgdir, "chap4.tst"));
-Test( Filename( pkgdir, "chap5.tst"));
-Test( Filename( pkgdir, "chap6.tst"));
-Test( Filename( pkgdir, "chap7.tst"));
-Test( Filename( pkgdir, "chap8.tst"));
-Test( Filename( pkgdir, "chap9.tst"));
-Test( Filename( pkgdir, "chap10.tst"));
+LoadPackage( "patternclass" );
+
+TestDirectory(DirectoriesPackageLibrary( "patternclass", "tst" ),
+  rec(exitGAP     := true,
+      testOptions := rec(compareFunction := "uptowhitespace") ) );
+
+FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
This PR switches to `TestDirectory` and tests all files in the `tst` directory. Now if you read `testall.g` in GAP, it produces this:
```
test file         GAP4stones     time(msec)
-------------------------------------------
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap10.tst
chap10.tst                 0             62
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap2.tst
chap2.tst                  0             61
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap3.tst
chap3.tst                  0             54
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap4.tst
chap4.tst                 19            524   ( next ~0 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap5.tst
chap5.tst                  0             70   ( next ~0 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap6.tst
chap6.tst                  0             98   ( next ~0 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap7.tst
chap7.tst                  0             55   ( next ~0 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap8.tst
chap8.tst                  0             60   ( next ~0 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/chap9.tst
chap9.tst                  2           4605   ( next ~2 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/experiments.tst
experiments.tst            0             59   ( next ~2 sec )
testing: /Users/alexk/GITREPS/gap-stable/pkg/PatternClass/tst/testall.tst
testall.tst                1           5105
-------------------------------------------
total                      3          10234

#I  No errors detected while testing
```
what permits automatic detection of passing/failing by GAP regression testing scripts.

