### PR TITLE
Remove 'HashSet' variable, as it clashes with Datastructures

### DIFF
--- a/lib/autGraphs.gd
+++ b/lib/autGraphs.gd
@@ -24,12 +24,6 @@
 
 #############################################################################
 ##
-#V  HashSet
-##
-DeclareGlobalVariable("HashSet");
-
-#############################################################################
-##
 #F  GraphToAut(g,innode,outnode)  
 ##
 ##  Returns an automaton representing the input token passing network.

--- a/lib/autGraphs.gi
+++ b/lib/autGraphs.gi
@@ -20,12 +20,6 @@
 
 #############################################################################
 ##
-#V HashSet
-##
-InstallValue(HashSet,  s->HashKeyBag(s,57,0,4+4*Length(s)));
-
-#############################################################################
-##
 #F  GraphToAut(g,innode,outnode)  
 ##
 ##  Returns an automaton representing the input token passing network.
@@ -35,7 +29,7 @@ InstallGlobalFunction(GraphToAut, function(g,innode,outnode)
             he,  x,  init, a;
 
     states := [[]];
-    ht := SparseHashTable(HashSet);
+    ht := SparseHashTable( s->HashKeyBag(s,57,0,4+4*Length(s)) );
     AddHashEntry(ht,[],1);
     tm := List([1..Length(g)], x-> [[]]);
     ins := g[innode];
@@ -131,7 +125,7 @@ InstallGlobalFunction(ConstrainedGraphToAut, function(g,innode,outnode,capacity)
             he,  x,  init, a;
 
     states := [[]];
-    ht := SparseHashTable(HashSet);
+    ht := SparseHashTable( s->HashKeyBag(s,57,0,4+4*Length(s)) );
     AddHashEntry(ht,[],1);
     tm := List([1..Length(g)], x-> [[]]);
     ins := g[innode];


### PR DESCRIPTION
This removes the 'HashSet' variable, as we'd like to use the name in datastructures.

I could have given it a different name, but seeing as it is only used to in two places, I just copied it in place. If you prefer, I could give it a different name instead.